### PR TITLE
Add support for real server type "fqdn"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tf*
 .terraform
 terraform-provider-fortiadc
+.idea

--- a/docs/resources/loadbalance_real_server.md
+++ b/docs/resources/loadbalance_real_server.md
@@ -11,13 +11,22 @@ resource "fortiadc_loadbalance_real_server" "myrealserver" {
   address6 = "::"
   status   = "enable"
 }
+
+resource "fortiadc_loadbalance_real_server" "myrealserver2" {
+  name   = "myrealserver"
+  type   = "fqdn"
+  fqdn   = "realserver.example.com"
+  status = "enable"
+}
 ```
 
 ## Argument Reference
 
 * `name` - (Required) Real server name.
-* `address` - (Required) Real server ipv4 address.
-* `address6` - (Optional) Real server ipv6 address. Defaults to `::`.
+* `type` - (Optional) Type, `"ip"` or `"fqdn"`, defaults to `"ip"`
+* `address` - (Optional) Real server ipv4 address. Only used when `type="ip"`
+* `address6` - (Optional) Real server ipv6 address. Only used when `type="ip"`. Defaults to `::`.
+* `fqdn` - (Optional) Real server Fully Qualified Domain. Only used when `type="fqdn"`
 * `status` - (Optional) Real server status. Defaults to `enable`.
 
 ## Attribute Reference

--- a/fortiadc/resource_fortiadc_loadbalance_real_server.go
+++ b/fortiadc/resource_fortiadc_loadbalance_real_server.go
@@ -2,6 +2,7 @@ package fortiadc
 
 import (
 	"errors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/Ouest-France/gofortiadc"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -18,6 +19,12 @@ func resourceFortiadcLoadbalanceRealServer() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"fqdn", "ip"}, false),
+				Default:      "ip",
+				Optional:     true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -25,12 +32,16 @@ func resourceFortiadcLoadbalanceRealServer() *schema.Resource {
 			},
 			"address": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"address6": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "::",
+			},
+			"fqdn": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"status": {
 				Type:     schema.TypeString,
@@ -46,9 +57,11 @@ func resourceFortiadcLoadbalanceRealServerCreate(d *schema.ResourceData, m inter
 
 	req := gofortiadc.LoadbalanceRealServer{
 		Mkey:     d.Get("name").(string),
+		Type:     d.Get("type").(string),
 		Status:   d.Get("status").(string),
 		Address:  d.Get("address").(string),
 		Address6: d.Get("address6").(string),
+		FQDN:     d.Get("fqdn").(string),
 	}
 
 	err := client.LoadbalanceCreateRealServer(req)
@@ -76,9 +89,11 @@ func resourceFortiadcLoadbalanceRealServerRead(d *schema.ResourceData, m interfa
 
 	arguments := map[string]interface{}{
 		"name":     rs.Mkey,
+		"type":     rs.Type,
 		"address":  rs.Address,
 		"address6": rs.Address6,
 		"status":   rs.Status,
+		"fqdn":     rs.FQDN,
 	}
 
 	for arg, value := range arguments {
@@ -96,9 +111,11 @@ func resourceFortiadcLoadbalanceRealServerUpdate(d *schema.ResourceData, m inter
 
 	req := gofortiadc.LoadbalanceRealServer{
 		Mkey:     d.Get("name").(string),
+		Type:     d.Get("type").(string),
 		Status:   d.Get("status").(string),
 		Address:  d.Get("address").(string),
 		Address6: d.Get("address6").(string),
+		FQDN:     d.Get("fqdn").(string),
 	}
 
 	err := client.LoadbalanceUpdateRealServer(req)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Ouest-France/terraform-provider-fortiadc
 go 1.18
 
 require (
-	github.com/Ouest-France/gofortiadc v0.2.1
+	github.com/Ouest-France/gofortiadc v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Ouest-France/gofortiadc v0.2.1 h1:H6zXmXwXBy5Y/VMUtISQCHmfzFYN+0wWyaHgy5XE5IE=
-github.com/Ouest-France/gofortiadc v0.2.1/go.mod h1:F/9dSjg4Be8NpKuA1FMQAlxiDvKzGH+/U1k6G7kseEs=
+github.com/Ouest-France/gofortiadc v0.3.0 h1:bWNc/gRUIQlt6+AxZOrPyhQEXGry0GfToN0zCANC84U=
+github.com/Ouest-France/gofortiadc v0.3.0/go.mod h1:CaVJpG2iVFKuFIIZtFW4wlLD50plEVAgOXRIGHir3ms=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
@@ -111,10 +111,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
Related gofortiadc changes: https://github.com/Ouest-France/gofortiadc/pull/19

- Add field `type` that can be the strings "ip" or "fqdn"
- Change `address` from Required to Optional, with no default
- Add string field `fqdn`

- Updated docs to reflect

I explored some options regarding AtLeastOneOf or ConflictsWith for the new fields, but from what I could tell in my research, making optional fields mutually exclusive is complicated and likely not worth it.


